### PR TITLE
Fix restart and update Ampache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get install --no-install-recommends -q -y apache2 php5 php5-json curl ph
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/www/*
 RUN cd /var/tmp \
- && curl -sSL --insecure https://github.com/ampache/ampache/archive/3.7.0.tar.gz | tar xz \
- && mv /var/tmp/ampache-3.7.0/* /var/www/ \
- && rm -rf /var/tmp/ampache-3.7.0 \
+ && curl -sSL --insecure https://github.com/ampache/ampache/archive/3.8.0.tar.gz | tar xz \
+ && mv /var/tmp/ampache-3.8.0/* /var/www/ \
+ && rm -rf /var/tmp/ampache-3.8.0 \
  && chown -R www-data:www-data /var/www/
 
 ADD 001-ampache.conf /etc/apache2/sites-available/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,8 @@ VOLUME ["/media"]
 VOLUME ["/var/www/config"]
 VOLUME ["/var/www/themes"]
 EXPOSE 80
-CMD ["/usr/sbin/apache2ctl", "-D",  "FOREGROUND"]
+
+ADD run.sh /run.sh
+RUN chmod 755 /run.sh
+CMD ["/run.sh"]
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+LOCKFILE=/run/apache2/apache2.pid
+
+# Previous apache should execute successfully:
+
+[ -f $LOCKFILE ] && exit 0
+
+# Upon exit, remove lockfile.
+
+trap "{ rm -f $LOCKFILE ; exit 255; }" EXIT
+
+/usr/sbin/apache2ctl -D FOREGROUND
+
+exit 0


### PR DESCRIPTION
Containers were not able to restart due to a pid file not being removed. (I think this is happening in many apache images).

Now apcahectl is run inside a script that traps EXIT signals (docker stop) and removes the pid file.

Also I updated Ampache to 3.8.0.